### PR TITLE
feat: add `parseInterpolationExpression`, deprecate `parseInterpolation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const ast = ngEstreeParser.parseBinding('a | b:c');
 
 - `parseAction(input: string): AST` for `(target)="input"`
 - `parseBinding(input: string): AST` for `[target]="input"`
-- `parseInterpolation(input: string): AST` for `{{input}}`
+- `parseInterpolationExpression(input: string): AST` for `{{input}}`
 - `parseTemplateBindings(input: string): AST` for `*directive="input"`
 
 ## Development

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import type { NGMicrosyntax, NGNode, RawNGComment } from './types.js';
 import {
   parseNgAction,
   parseNgBinding,
-  parseNgInterpolation,
+  parseNgInterpolationExpression,
   parseNgSimpleBinding,
   parseNgTemplateBindings,
 } from './utils.js';
@@ -34,8 +34,8 @@ export function parseSimpleBinding(input: string): NGNode {
   return parse(input, parseNgSimpleBinding);
 }
 
-export function parseInterpolation(input: string): NGNode {
-  return parse(input, parseNgInterpolation);
+export function parseInterpolationExpression(input: string): NGNode {
+  return parse(input, parseNgInterpolationExpression);
 }
 
 export function parseAction(input: string): NGNode {
@@ -48,3 +48,6 @@ export function parseTemplateBindings(input: string): NGMicrosyntax {
     new Context(input),
   );
 }
+
+// TODO: Remove this in next major
+export const parseInterpolation = parseInterpolationExpression;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,6 +43,12 @@ export function parseNgAction(input: string) {
   );
 }
 
+export function parseNgInterpolationExpression(input: string) {
+  return parseNg(input, (astInput, ngParser) =>
+    ngParser.parseInterpolationExpression(astInput, ...NG_PARSE_SHARED_PARAMS),
+  );
+}
+
 export function parseNgTemplateBindings(input: string) {
   const ngParser = createNgParser();
   const { templateBindings: ast, errors } = ngParser.parseTemplateBindings(
@@ -54,23 +60,6 @@ export function parseNgTemplateBindings(input: string) {
   );
   assertAstErrors(errors);
   return ast;
-}
-
-export function parseNgInterpolation(input: string) {
-  const ngParser = createNgParser();
-  const { astInput, comments } = extractComments(input, ngParser);
-  const prefix = '{{';
-  const suffix = '}}';
-
-  const { ast: rawAst, errors } = ngParser.parseInterpolation(
-    prefix + astInput + suffix,
-    NG_PARSE_FAKE_LOCATION,
-    -prefix.length,
-    null,
-  )!;
-  assertAstErrors(errors);
-  const ast = (rawAst as ng.Interpolation).expressions[0];
-  return { ast, comments };
 }
 
 function assertAstErrors(errors: ng.ParserError[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,9 +44,14 @@ export function parseNgAction(input: string) {
 }
 
 export function parseNgInterpolationExpression(input: string) {
-  return parseNg(input, (astInput, ngParser) =>
-    ngParser.parseInterpolationExpression(astInput, ...NG_PARSE_SHARED_PARAMS),
-  );
+  return parseNg(input, (astInput, ngParser) => {
+    const result = ngParser.parseInterpolationExpression(
+      astInput,
+      ...NG_PARSE_SHARED_PARAMS,
+    );
+    result.ast = (result.ast as ng.Interpolation).expressions[0];
+    return result;
+  });
 }
 
 export function parseNgTemplateBindings(input: string) {

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -3,7 +3,7 @@ import type * as b from '@babel/types';
 import {
   parseAction,
   parseBinding,
-  parseInterpolation,
+  parseInterpolationExpression,
   parseSimpleBinding,
 } from '../src/index.js';
 import type { NGNode } from '../src/types.js';
@@ -11,7 +11,7 @@ import {
   getNgType,
   parseNgAction,
   parseNgBinding,
-  parseNgInterpolation,
+  parseNgInterpolationExpression,
   parseNgSimpleBinding,
 } from '../src/utils.js';
 import {
@@ -111,7 +111,11 @@ describe.each`
   testSection('action', parseNgAction, parseAction);
   testSection('binding', parseNgBinding, parseBinding);
   testSection('simple', parseNgSimpleBinding, parseSimpleBinding);
-  testSection('interpolation', parseNgInterpolation, parseInterpolation);
+  testSection(
+    'interpolation',
+    parseNgInterpolationExpression,
+    parseInterpolationExpression,
+  );
 
   test('ast', () => {
     expect(beforeNode).not.toEqual(null);

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -32,7 +32,7 @@ describe.each`
   ${'BindingPipe'}      | ${'NGPipeExpression'}         | ${' a | b : c '}            | ${false} | ${true}  | ${false} | ${true}
   ${'Chain'}            | ${'NGChainedExpression'}      | ${' a ; b '}                | ${true}  | ${false} | ${false} | ${false}
   ${'Conditional'}      | ${'ConditionalExpression'}    | ${' a ? 1 : 2 '}            | ${true}  | ${true}  | ${true}  | ${true}
-  ${'EmptyExpr'}        | ${'NGEmptyExpression'}        | ${''}                       | ${true}  | ${true}  | ${true}  | ${false}
+  ${'EmptyExpr'}        | ${'NGEmptyExpression'}        | ${''}                       | ${true}  | ${true}  | ${true}  | ${true}
   ${'Call'}             | ${'CallExpression'}           | ${' ( a . b ) ( 1 , 2 ) '}  | ${true}  | ${true}  | ${true}  | ${true}
   ${'SafeCall'}         | ${'OptionalCallExpression'}   | ${' ( a . b )?.( 1 , 2 ) '} | ${true}  | ${true}  | ${true}  | ${true}
   ${'Call'}             | ${'CallExpression'}           | ${' ( a ) ( 1 , 2 ) '}      | ${true}  | ${true}  | ${true}  | ${true}


### PR DESCRIPTION
I found there is another `parseInterpolationExpression` method, so we don't need wrap input with `{{}}`.